### PR TITLE
Remove directory component from dbfilename

### DIFF
--- a/lib/redis-store/testing/config/node-one.conf
+++ b/lib/redis-store/testing/config/node-one.conf
@@ -1,5 +1,5 @@
 daemonize yes
-pidfile ./tmp/pids/node-one.pid
+pidfile ./pids/node-one.pid
 port 6380
 timeout 0
 loglevel verbose
@@ -13,8 +13,8 @@ save 60 10000
 # stop-writes-on-bgsave-error yes
 rdbcompression yes
 # rdbchecksum yes
-dbfilename tmp/node-one-dump.rdb
-dir ./
+dbfilename node-one-dump.rdb
+dir ./tmp
 
 slave-serve-stale-data yes
 # slave-read-only yes

--- a/lib/redis-store/testing/config/node-two.conf
+++ b/lib/redis-store/testing/config/node-two.conf
@@ -1,5 +1,5 @@
 daemonize yes
-pidfile ./tmp/pids/node-two.pid
+pidfile ./pids/node-two.pid
 port 6381
 timeout 0
 loglevel verbose
@@ -13,8 +13,8 @@ save 60 10000
 # stop-writes-on-bgsave-error yes
 rdbcompression yes
 # rdbchecksum yes
-dbfilename tmp/node-two-dump.rdb
-dir ./
+dbfilename node-two-dump.rdb
+dir ./tmp
 
 slave-serve-stale-data yes
 # slave-read-only yes

--- a/lib/redis-store/testing/config/redis.conf
+++ b/lib/redis-store/testing/config/redis.conf
@@ -1,5 +1,5 @@
 daemonize yes
-pidfile ./tmp/pids/redis.pid
+pidfile ./pids/redis.pid
 port 6379
 timeout 0
 loglevel verbose
@@ -13,8 +13,8 @@ save 60 10000
 # stop-writes-on-bgsave-error yes
 rdbcompression yes
 # rdbchecksum yes
-dbfilename tmp/dump.rdb
-dir ./
+dbfilename dump.rdb
+dir ./tmp
 
 slave-serve-stale-data yes
 # slave-read-only yes


### PR DESCRIPTION
Redis 2.8.11 gives an error if you say `dbfilename my_dir/dump.rdb`. It
seems you are supposed to write this instead:

```
dbfilename dump.rdb
dir mydir
```

This patch updates the bundled configuration files for this new syntax.
