### PR TITLE
Fix Redis configuration files (closes #1)

### DIFF
--- a/lib/redis-store/testing/config/node-one.conf
+++ b/lib/redis-store/testing/config/node-one.conf
@@ -13,8 +13,8 @@ save 60 10000
 # stop-writes-on-bgsave-error yes
 rdbcompression yes
 # rdbchecksum yes
-dbfilename tmp/node-one-dump.rdb
-dir ./
+dbfilename node-one-dump.rdb
+dir ./tmp
 
 slave-serve-stale-data yes
 # slave-read-only yes

--- a/lib/redis-store/testing/config/node-two.conf
+++ b/lib/redis-store/testing/config/node-two.conf
@@ -13,8 +13,8 @@ save 60 10000
 # stop-writes-on-bgsave-error yes
 rdbcompression yes
 # rdbchecksum yes
-dbfilename tmp/node-two-dump.rdb
-dir ./
+dbfilename node-two-dump.rdb
+dir ./tmp
 
 slave-serve-stale-data yes
 # slave-read-only yes

--- a/lib/redis-store/testing/config/redis.conf
+++ b/lib/redis-store/testing/config/redis.conf
@@ -13,8 +13,8 @@ save 60 10000
 # stop-writes-on-bgsave-error yes
 rdbcompression yes
 # rdbchecksum yes
-dbfilename tmp/dump.rdb
-dir ./
+dbfilename dump.rdb
+dir ./tmp
 
 slave-serve-stale-data yes
 # slave-read-only yes


### PR DESCRIPTION
This patch fixes "dbfilename can't be a path, just a filename" errors from Redis config files.

Along with [this pull request](https://github.com/redis-store/redis-activesupport/pull/19), it should allow Travis builds to pass again.
